### PR TITLE
[Feat/#17] 로그인 흐름 분기, UX 개선, 모달·토스트 시스템 도입

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "axios": "^1.8.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.3.0"
+        "react-router-dom": "^7.3.0",
+        "sonner": "^2.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -6054,6 +6055,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.3.tgz",
+      "integrity": "sha512-njQ4Hht92m0sMqqHVDL32V2Oun9W1+PHO9NDv9FHfJjT3JT22IG4Jpo3FPQy+mouRKCXFWO+r67v6MrHX2zeIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "axios": "^1.8.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.3.0"
+    "react-router-dom": "^7.3.0",
+    "sonner": "^2.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
+import { Toaster } from "sonner";
 import Router from "./Router";
 
 const App = () => {
-  return <Router />;
+  return (
+    <>
+      <Router />
+      <Toaster position="top-right" duration={3000} />
+    </>
+  );
 };
 
 export default App;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -7,6 +7,9 @@ import {
   InterviewSetupPage,
   LandingPage,
   OAuthCallbackPage,
+  PreFeedbackPage,
+  PreInterviewPage,
+  PreInterviewSetupPage,
 } from "./pages";
 
 const Router = () => {
@@ -14,9 +17,17 @@ const Router = () => {
     <Routes>
       <Route path={ROUTES.ROOT} element={<Layout />}>
         <Route index element={<LandingPage />} />
+
+        {/* 비로그인 사용자용 로직 */}
+        <Route path={ROUTES.PRE_OPTION} element={<PreInterviewSetupPage />} />
+        <Route path={ROUTES.PRE_INTERVIEW} element={<PreInterviewPage />} />
+        <Route path={ROUTES.PRE_FEEDBACK} element={<PreFeedbackPage />} />
+
+        {/* 로그인 사용자용 로직 */}
         <Route path={ROUTES.OPTION} element={<InterviewSetupPage />} />
         <Route path={ROUTES.INTERVIEW} element={<InterviewPage />} />
         <Route path={ROUTES.FEEDBACK} element={<FeedbackPage />} />
+
         <Route path={ROUTES.OAUTH_CALLBACK} element={<OAuthCallbackPage />} />
       </Route>
     </Routes>

--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -8,6 +8,7 @@ import { postRefreshAccessToken } from "./auth";
 
 let isAlertShown = false;
 
+// 공통 API 클라이언트
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
   headers: {
@@ -52,4 +53,5 @@ apiClient.interceptors.response.use(
   },
 );
 
+// 요청 인터셉터
 apiClient.interceptors.request.use((config) => config);

--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -3,6 +3,7 @@
 import axios from "axios";
 import { API_BASE_URL } from "../constants";
 import { getAuthState, markRefreshAttempted, markRefreshFailed } from "../state/authState";
+import showToast from "../utils/toast";
 import { postRefreshAccessToken } from "./auth";
 
 let isAlertShown = false;
@@ -39,7 +40,7 @@ apiClient.interceptors.response.use(
 
         if (!isAlertShown) {
           isAlertShown = true;
-          alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+          showToast({ type: "warning", message: "세션이 만료되었습니다. 다시 로그인해주세요." });
           window.location.href = "/";
         }
 

--- a/src/api/question.ts
+++ b/src/api/question.ts
@@ -3,6 +3,20 @@
 import { API_ENDPOINTS } from "../constants";
 import { apiClient } from "./core";
 
+// 맛보기 로직용 직무 선택
+export const postJobIdOption = async (jobId: number) => {
+  try {
+    const response = await apiClient.post(`/${API_ENDPOINTS.PRE_QUESTION}`, {
+      jobId,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error("[postJobIdOption] 요청 실패:", error);
+    throw new Error("맛보기용 인터뷰 시작 요청에 실패했어요. 잠시 후 다시 시도해주세요.");
+  }
+};
+
 // 직무, 질문 개수 선택
 export const postQuestionOption = async (
   jobId: number,

--- a/src/api/question.ts
+++ b/src/api/question.ts
@@ -3,13 +3,17 @@
 import { API_ENDPOINTS } from "../constants";
 import { apiClient } from "./core";
 
-// 질문 개수 선택
-export const postQuestionOption = async (techCount: number, personalityCount: number) => {
+// 직무, 질문 개수 선택
+export const postQuestionOption = async (
+  jobId: number,
+  personalityCount: number,
+  techCount: number,
+) => {
   try {
     const response = await apiClient.post(`/${API_ENDPOINTS.QUESTION}`, {
-      techCount,
+      jobId,
       personalityCount,
-      jobId: 0, // 현재는 무조건 프론트엔드
+      techCount,
     });
 
     return response.data;

--- a/src/api/question.ts
+++ b/src/api/question.ts
@@ -40,16 +40,19 @@ export const postQuestionOption = async (
 // 답변 제출
 export const postUserAnswer = async ({
   userId,
+  interviewId,
   questionId,
   userAnswer,
 }: {
   userId: number;
+  interviewId: number;
   questionId: number;
   userAnswer: string;
 }) => {
   try {
     const response = await apiClient.post(`/${API_ENDPOINTS.ANSWERS}`, {
       userId,
+      interviewId,
       questionId,
       userAnswer,
     });
@@ -62,10 +65,16 @@ export const postUserAnswer = async ({
 };
 
 // 모든 질문 및 답안 조회
-export const getAllAnswer = async (userId: number) => {
+export const getAllAnswer = async ({
+  userId,
+  interviewId,
+}: {
+  userId: number;
+  interviewId: number;
+}) => {
   try {
     const response = await apiClient.get(`/${API_ENDPOINTS.RESULT}`, {
-      params: { userId },
+      params: { userId, interviewId },
     });
 
     return response.data;

--- a/src/components/common/AuthButton.tsx
+++ b/src/components/common/AuthButton.tsx
@@ -1,0 +1,40 @@
+import { UserCircleIcon } from "@heroicons/react/24/outline";
+import { useNavigate } from "react-router-dom";
+import { ROUTES } from "../../constants";
+import { useAuth } from "../../hooks/useAuth";
+import redirectToGithubAuthorize from "../../utils/oauth";
+import { Button } from "../common";
+
+const AuthButton = () => {
+  const navigate = useNavigate();
+  const { user, isLogin, logout } = useAuth();
+
+  const handleGithubLogin = () => {
+    if (!isLogin) redirectToGithubAuthorize();
+    else navigate(ROUTES.ROOT);
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    navigate(ROUTES.ROOT);
+  };
+
+  return isLogin ? (
+    // 로그인 상태 → 프로필 이미지 + Logout 버튼
+    <Button onClick={handleLogout} className="flex items-center gap-1 text-gray8 hover:bg-blue2">
+      <img src={user?.avatar} alt="프로필" className="size-[28px] rounded-full" />
+      <p className="font-semibold">Logout</p>
+    </Button>
+  ) : (
+    // 비로그인 상태 → Login 버튼
+    <Button
+      onClick={handleGithubLogin}
+      className="flex items-center gap-1 text-gray8 hover:bg-blue2"
+    >
+      <UserCircleIcon className="size-[28px]" />
+      <p className="font-semibold">Login</p>
+    </Button>
+  );
+};
+
+export default AuthButton;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -3,13 +3,20 @@ interface ButtonProps {
   children?: React.ReactNode;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   className?: string;
+  disabled?: boolean;
 }
 
-const Button = ({ label, children, onClick, className }: ButtonProps) => {
+const Button = ({ label, children, onClick, className, disabled = false }: ButtonProps) => {
+  const disabledStyle = "bg-gray2 text-gray6 cursor-not-allowed";
+
   return (
     <button
-      onClick={onClick}
-      className={`${className} rounded-lg px-6 py-2 transition-transform duration-200 hover:scale-105`}
+      onClick={(e) => {
+        if (disabled) return;
+        onClick?.(e);
+      }}
+      disabled={disabled}
+      className={`${disabled ? disabledStyle : className} rounded-lg px-6 py-2 transition-transform duration-200 hover:scale-105`}
     >
       {children ?? label}
     </button>

--- a/src/components/common/CustomToast.tsx
+++ b/src/components/common/CustomToast.tsx
@@ -21,7 +21,7 @@ const ICON_MAP = {
 
 const CustomToast = ({ type, message }: CustomToastProps) => {
   return (
-    <div className="flex max-w-md items-center gap-2 rounded-md bg-white px-4 py-3 shadow-md">
+    <div className="inline-flex items-center gap-2 rounded-md bg-white px-4 py-3 shadow-md">
       <div className="shrink-0">{ICON_MAP[type]}</div>
       <div className="flex-1 whitespace-nowrap text-sm">{message}</div>
     </div>

--- a/src/components/common/CustomToast.tsx
+++ b/src/components/common/CustomToast.tsx
@@ -1,0 +1,31 @@
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InformationCircleIcon,
+} from "@heroicons/react/24/outline";
+
+type ToastType = "success" | "error" | "info" | "warning";
+
+interface CustomToastProps {
+  type: ToastType;
+  message: string;
+}
+
+const ICON_MAP = {
+  success: <CheckCircleIcon className="h-5 w-5 text-green-800" />,
+  error: <ExclamationCircleIcon className="h-5 w-5 text-red-800" />,
+  info: <InformationCircleIcon className="h-5 w-5 text-blue-800" />,
+  warning: <ExclamationTriangleIcon className="h-5 w-5 text-yellow-800" />,
+};
+
+const CustomToast = ({ type, message }: CustomToastProps) => {
+  return (
+    <div className="flex max-w-md items-center gap-2 rounded-md bg-white px-4 py-3 shadow-md">
+      <div className="shrink-0">{ICON_MAP[type]}</div>
+      <div className="flex-1 whitespace-nowrap text-sm">{message}</div>
+    </div>
+  );
+};
+
+export default CustomToast;

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  content?: React.ReactNode;
+  actions?: React.ReactNode;
+}
+
+const Modal = ({ isOpen, onClose, title, content, actions }: ModalProps) => {
+  const [mounted, setMounted] = useState(false); // 클라이언트 렌더링 여부
+
+  // 클라이언트에서만 모달 렌더링
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  // 모달 열릴 때 스크롤 비활성화
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  if (!isOpen || !mounted) return null;
+
+  const portalRoot = document.getElementById("modal-root");
+  if (!portalRoot) {
+    console.error("modal-root가 HTML에 없습니다.");
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="bg-black-60 fixed inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="flex flex-col rounded-lg bg-white p-6 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 닫기 버튼*/}
+        <div className="flex justify-end">
+          <button onClick={onClose} className="cursor w-fit text-sm text-gray8 hover:underline">
+            닫기
+          </button>
+        </div>
+
+        {/* 내용 영역 */}
+        <div className="flex flex-col gap-6">
+          {title && <h2 className="text-2xl font-bold text-black">{title}</h2>}
+          {content && <div className="text-lg text-gray8">{content}</div>}
+          {actions && <div className="flex flex-col gap-3 text-lg">{actions}</div>}
+        </div>
+      </div>
+    </div>,
+    portalRoot,
+  );
+};
+
+export default Modal;

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -32,6 +32,7 @@ const Modal = ({ isOpen, onClose, title, content, actions }: ModalProps) => {
 
   if (!isOpen || !mounted) return null;
 
+  // 포탈을 붙일 DOM 요소
   const portalRoot = document.getElementById("modal-root");
   if (!portalRoot) {
     console.error("modal-root가 HTML에 없습니다.");

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -41,7 +41,7 @@ const Modal = ({ isOpen, onClose, title, content, actions }: ModalProps) => {
 
   return createPortal(
     <div
-      className="bg-black-60 fixed inset-0 z-50 flex items-center justify-center"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black-60"
       onClick={onClose}
     >
       <div
@@ -50,7 +50,10 @@ const Modal = ({ isOpen, onClose, title, content, actions }: ModalProps) => {
       >
         {/* 닫기 버튼*/}
         <div className="flex justify-end">
-          <button onClick={onClose} className="cursor w-fit text-sm text-gray8 hover:underline">
+          <button
+            onClick={onClose}
+            className="w-fit cursor-pointer text-sm text-gray8 hover:underline"
+          >
             닫기
           </button>
         </div>

--- a/src/components/common/SelectBox.tsx
+++ b/src/components/common/SelectBox.tsx
@@ -23,19 +23,21 @@ const SelectBox = ({ options, placeholder, value, onChange }: SelectBoxProps) =>
     setIsOpen(false);
   };
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
+  // 외부 클릭 시 드롭다운 닫기
+  const handleClickOutside = (e: MouseEvent) => {
+    if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      setIsOpen(false);
+    }
+  };
 
+  useEffect(() => {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
   return (
     <div className="relative w-[360px]" ref={containerRef}>
+      {/* 선택 영역 버튼 */}
       <button
         onClick={toggleDropdown}
         className="flex w-full items-center justify-between rounded-md border border-gray4 bg-white px-4 py-2 text-base text-gray6 shadow-sm focus:outline-none"
@@ -52,6 +54,7 @@ const SelectBox = ({ options, placeholder, value, onChange }: SelectBoxProps) =>
         </span>
       </button>
 
+      {/* 드롭다운 옵션 영역 */}
       <div
         className={`absolute z-10 mt-2 w-full rounded-md border border-gray4 bg-white shadow-md transition-all duration-200 ease-out ${
           isOpen ? "translate-y-0 opacity-100" : "pointer-events-none -translate-y-1 opacity-0"

--- a/src/components/common/SelectBox.tsx
+++ b/src/components/common/SelectBox.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 
+interface SelectBoxOption {
+  label: string;
+  value: string;
+}
+
 interface SelectBoxProps {
-  options: string[];
+  options: SelectBoxOption[];
   placeholder: string;
   value: string;
   onChange: (selected: string) => void;
@@ -36,7 +41,7 @@ const SelectBox = ({ options, placeholder, value, onChange }: SelectBoxProps) =>
         className="flex w-full items-center justify-between rounded-md border border-gray4 bg-white px-4 py-2 text-base text-gray6 shadow-sm focus:outline-none"
       >
         <span className="overflow-hidden text-ellipsis whitespace-nowrap">
-          {value || placeholder}
+          {options.find((opt) => opt.value === value)?.label || placeholder}
         </span>
         <span
           className={`inline-block text-xs text-gray5 transition-transform duration-200 ${
@@ -53,13 +58,13 @@ const SelectBox = ({ options, placeholder, value, onChange }: SelectBoxProps) =>
         }`}
       >
         <ul className="max-h-60 overflow-y-auto">
-          {options.map((option) => (
+          {options.map(({ label, value }) => (
             <li
-              key={option}
-              onClick={() => handleSelect(option)}
+              key={value}
+              onClick={() => handleSelect(value)}
               className="cursor-pointer px-4 py-2 text-base text-black transition-colors hover:bg-gray1"
             >
-              {option}
+              {label}
             </li>
           ))}
         </ul>

--- a/src/components/common/Timer.tsx
+++ b/src/components/common/Timer.tsx
@@ -2,15 +2,23 @@ import { useEffect, useState } from "react";
 
 interface TimerProps {
   time: number;
+  onTimeOver?: () => void;
+  onBeforeEnd?: () => void;
 }
 
-const Timer = ({ time }: TimerProps) => {
+const Timer = ({ time, onTimeOver, onBeforeEnd }: TimerProps) => {
   const [remaining, setRemaining] = useState(time);
+  const [notified, setNotified] = useState(false);
 
   useEffect(() => {
     if (remaining <= 0) {
-      alert("시간이 종료되었어요. 다음 질문으로 넘어가요.");
+      onTimeOver?.();
       return;
+    }
+
+    if (remaining === 10 && !notified) {
+      onBeforeEnd?.();
+      setNotified(true);
     }
 
     const interval = setInterval(() => {
@@ -18,7 +26,7 @@ const Timer = ({ time }: TimerProps) => {
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [remaining]);
+  }, [remaining, onTimeOver, onBeforeEnd, notified]);
 
   const minutes = String(Math.floor(remaining / 60)).padStart(2, "0");
   const seconds = String(remaining % 60).padStart(2, "0");

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,4 +1,5 @@
 export { default as AnswerInput } from "./AnswerInput";
+export { default as AuthButton } from "./AuthButton";
 export { default as Button } from "./Button";
 export { default as Counter } from "./Counter";
 export { default as CustomToast } from "./CustomToast";

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,6 +1,7 @@
 export { default as AnswerInput } from "./AnswerInput";
 export { default as Button } from "./Button";
 export { default as Counter } from "./Counter";
+export { default as CustomToast } from "./CustomToast";
 export { default as LoadingFallback } from "./LoadingFallback";
 export { default as ModelAnswer } from "./ModelAnswer";
 export { default as Question } from "./Question";

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,6 +3,7 @@ export { default as Button } from "./Button";
 export { default as Counter } from "./Counter";
 export { default as CustomToast } from "./CustomToast";
 export { default as LoadingFallback } from "./LoadingFallback";
+export { default as Modal } from "./Modal";
 export { default as ModelAnswer } from "./ModelAnswer";
 export { default as Question } from "./Question";
 export { default as SelectBox } from "./SelectBox";

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,35 +1,9 @@
-import { UserCircleIcon } from "@heroicons/react/24/outline";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "../../constants";
-import { useAuth } from "../../hooks/useAuth";
-import { Button } from "../common";
+import { AuthButton, Button } from "../common";
 
 const Header = () => {
   const navigate = useNavigate();
-  const { user, isLogin, logout } = useAuth();
-
-  const handleGithubLogin = async () => {
-    if (isLogin) return navigate(ROUTES.ROOT);
-    redirectToGithubAuthorize();
-  };
-
-  const handleLogout = async () => {
-    await logout();
-    navigate(ROUTES.ROOT);
-  };
-
-  const redirectToGithubAuthorize = () => {
-    const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID;
-    const redirectUri = import.meta.env.VITE_GITHUB_REDIRECT_URI;
-
-    if (!clientId || !redirectUri) {
-      console.error("[GitHubLogin] OAuth 설정 누락");
-      return;
-    }
-
-    const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user user:email`;
-    window.location.href = githubAuthUrl;
-  };
 
   return (
     <header className="flex h-[70px] w-full items-center justify-between border-b border-solid border-gray2">
@@ -38,25 +12,7 @@ const Header = () => {
         onClick={() => navigate(ROUTES.ROOT)}
         className="px-4 text-xl font-black"
       />
-      <div>
-        {isLogin ? (
-          <Button
-            onClick={handleLogout}
-            className="flex items-center gap-1 text-gray8 hover:bg-blue2"
-          >
-            <img src={user?.avatar} alt="프로필" className="size-[28px] rounded-full" />
-            <p className="font-semibold">Logout</p>
-          </Button>
-        ) : (
-          <Button
-            onClick={handleGithubLogin}
-            className="flex items-center gap-1 text-gray8 hover:bg-blue2"
-          >
-            <UserCircleIcon className="size-[28px]" />
-            <p className="font-semibold">Login</p>
-          </Button>
-        )}
-      </div>
+      <AuthButton />
     </header>
   );
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ export const API_BASE_URL =
   import.meta.env.VITE_MOCK_MODE === "true" ? "" : import.meta.env.VITE_API_BASE_URL;
 
 export const API_ENDPOINTS = {
+  PRE_QUESTION: "prequestion",
   QUESTION: "question",
   ANSWERS: "answers",
   RESULT: "result",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,9 @@ export const API_ENDPOINTS = {
 
 export const ROUTES = {
   ROOT: "/",
+  PRE_OPTION: "preOption",
+  PRE_INTERVIEW: "preInterview",
+  PRE_FEEDBACK: "preFeedback",
   OPTION: "option",
   INTERVIEW: "interview",
   FEEDBACK: "feedback",

--- a/src/context/AuthContext.ts
+++ b/src/context/AuthContext.ts
@@ -1,4 +1,5 @@
 import { createContext } from "react";
 import { AuthContextType } from "./types";
 
+// 전역에서 로그인 상태를 관리하기 위한 AuthContext 생성
 export const AuthContext = createContext<AuthContextType | null>(null);

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -7,10 +7,11 @@ import { AuthContext } from "./AuthContext";
 import { User } from "./types";
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const [user, setUser] = useState<User | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const lastUsedCode = useRef<string | null>(null);
+  const [user, setUser] = useState<User | null>(null); // 현재 로그인한 사용자 정보
+  const [isLoading, setIsLoading] = useState(false); // 로그인 처리 중 로딩 상태
+  const lastUsedCode = useRef<string | null>(null); // 중복 로그인 요청 방지를 위한 code 추적
 
+  // GitHub OAuth 로그인
   const loginWithCode = async (code: string) => {
     if (lastUsedCode.current === code) {
       console.warn("[AuthProvider] 중복된 code로 로그인 시도 방지됨");
@@ -32,6 +33,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
+  // 로그아웃 처리
   const logout = async () => {
     try {
       await postGithubLogout();
@@ -49,6 +51,16 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
+  // 로딩 중에는 fallback 컴포넌트 보여줌
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center">
+        <LoadingFallback message="로그인 상태 확인 중입니다..." />
+      </div>
+    );
+  }
+
+  // 로그인 상태 컨텍스트 전역 제공
   return (
     <AuthContext.Provider
       value={{
@@ -59,13 +71,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         loginWithCode,
       }}
     >
-      {isLoading ? (
-        <div className="flex min-h-screen flex-col items-center justify-center">
-          <LoadingFallback message="로그인 상태 확인 중입니다..." />
-        </div>
-      ) : (
-        children
-      )}
+      {children}
     </AuthContext.Provider>
   );
 };

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { getCurrentUser, postGithubLogin, postGithubLogout } from "../api/auth";
 import { LoadingFallback } from "../components/common";
 import { resetAuthState } from "../state/authState";
+import showToast from "../utils/toast";
 import { AuthContext } from "./AuthContext";
 import { User } from "./types";
 
@@ -36,7 +37,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       await postGithubLogout();
     } catch (error) {
       console.warn("[AuthProvider] 로그아웃 요청 실패:", error);
-      alert("서버에 로그아웃 요청을 보내지 못했어요. 잠시 후 다시 시도해주세요.");
+      showToast({
+        type: "error",
+        message: "서버에 로그아웃 요청을 보내지 못했어요. 잠시 후 다시 시도해주세요.",
+      });
     } finally {
       setTimeout(() => {
         resetAuthState();

--- a/src/pages/FeedbackPage.tsx
+++ b/src/pages/FeedbackPage.tsx
@@ -10,6 +10,7 @@ const FeedbackPage = () => {
   const location = useLocation();
   const userId = location.state?.userId;
 
+  // userId가 없으면 홈으로 리다이렉트
   useEffect(() => {
     if (!userId) {
       navigate(ROUTES.ROOT, { replace: true });
@@ -18,23 +19,37 @@ const FeedbackPage = () => {
 
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
 
+  // 답변 데이터 불러오기
   const { data, isLoading, isError } = useQuery({
     queryKey: ["answerResult", userId],
     queryFn: () => getAllAnswer(userId),
     enabled: !!userId,
   });
 
+  // 로딩 및 에러 처리
   if (isLoading) return <p>로딩 중...</p>;
   if (isError || !data) return <p>답변을 불러오는 데 실패했습니다.</p>;
 
   const { totalCount, results } = data;
   const currentItem = results[currentQuestionIndex];
 
+  // 다음 질문으로 이동하거나 마지막엔 홈으로
+  const handleNextOrExit = () => {
+    const isLast = currentQuestionIndex === results.length - 1;
+
+    if (isLast) {
+      navigate(ROUTES.ROOT);
+    } else {
+      setCurrentQuestionIndex((prev) => prev + 1);
+    }
+  };
+
   return (
     <div
       className="mx-auto flex h-full w-full max-w-[1200px] flex-col"
       style={{ height: "calc(100vh - 130px)" }}
     >
+      {/* 질문 및 답변 표시 영역 */}
       <div className="flex w-full max-w-[1200px] flex-1 flex-col px-4 py-6">
         <Question text={currentItem.content} />
         <div className="mb-2 flex flex-col">
@@ -47,23 +62,16 @@ const FeedbackPage = () => {
         </div>
       </div>
 
+      {/* 하단 네비게이션 영역 */}
       <div className="flex w-full max-w-[1200px] items-center justify-between p-4 pt-6">
         <div className="flex-1"></div>
         <Counter current={currentQuestionIndex + 1} total={totalCount} />
         <div className="flex flex-1 justify-end">
-          {currentQuestionIndex === results.length - 1 ? (
-            <Button
-              label="나가기"
-              onClick={() => navigate(ROUTES.ROOT)}
-              className="bg-blue3 text-lg text-white shadow-md"
-            />
-          ) : (
-            <Button
-              label="다음"
-              onClick={() => setCurrentQuestionIndex((prev) => prev + 1)}
-              className="bg-blue3 text-lg text-white shadow-md"
-            />
-          )}
+          <Button
+            label={currentQuestionIndex === results.length - 1 ? "나가기" : "다음"}
+            onClick={handleNextOrExit}
+            className="bg-blue3 text-lg text-white shadow-md"
+          />
         </div>
       </div>
     </div>

--- a/src/pages/FeedbackPage.tsx
+++ b/src/pages/FeedbackPage.tsx
@@ -64,7 +64,13 @@ const FeedbackPage = () => {
         </div>
         <div className="flex flex-col">
           <span className="py-1 font-semibold text-gray8">모범 답안</span>
-          <ModelAnswer text={currentItem.modelAnswer} />
+          {currentItem.modelAnswer.trim() === "" ? (
+            <div className="w-full resize-none rounded-lg border border-gray4 p-3 italic text-gray5">
+              ❗ 모범 답안이 제공되지 않았어요.
+            </div>
+          ) : (
+            <ModelAnswer text={currentItem.modelAnswer} />
+          )}
         </div>
       </div>
 

--- a/src/pages/FeedbackPage.tsx
+++ b/src/pages/FeedbackPage.tsx
@@ -8,7 +8,7 @@ import { ROUTES } from "../constants";
 const FeedbackPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const userId = location.state?.userId;
+  const { userId, interviewId } = location.state;
 
   // userId가 없으면 홈으로 리다이렉트
   useEffect(() => {
@@ -22,7 +22,7 @@ const FeedbackPage = () => {
   // 답변 데이터 불러오기
   const { data, isLoading, isError } = useQuery({
     queryKey: ["answerResult", userId],
-    queryFn: () => getAllAnswer(userId),
+    queryFn: () => getAllAnswer({ userId, interviewId }),
     enabled: !!userId,
   });
 

--- a/src/pages/FeedbackPage.tsx
+++ b/src/pages/FeedbackPage.tsx
@@ -55,7 +55,7 @@ const FeedbackPage = () => {
         <div className="mb-2 flex flex-col">
           <span className="py-1 font-semibold text-gray8">작성 답안</span>
           {currentItem.userAnswer.trim() === "" ? (
-            <div className="w-full resize-none rounded-lg border border-gray4 p-3 text-gray8">
+            <div className="w-full resize-none rounded-lg border border-gray4 p-3 italic text-gray6">
               ❌ 아무 입력을 하지 않았어요.
             </div>
           ) : (
@@ -65,7 +65,7 @@ const FeedbackPage = () => {
         <div className="flex flex-col">
           <span className="py-1 font-semibold text-gray8">모범 답안</span>
           {currentItem.modelAnswer.trim() === "" ? (
-            <div className="w-full resize-none rounded-lg border border-gray4 p-3 italic text-gray5">
+            <div className="w-full resize-none rounded-lg border border-gray4 bg-gray2 p-3 italic text-gray6">
               ❗ 모범 답안이 제공되지 않았어요.
             </div>
           ) : (

--- a/src/pages/FeedbackPage.tsx
+++ b/src/pages/FeedbackPage.tsx
@@ -54,7 +54,13 @@ const FeedbackPage = () => {
         <Question text={currentItem.content} />
         <div className="mb-2 flex flex-col">
           <span className="py-1 font-semibold text-gray8">작성 답안</span>
-          <AnswerInput value={currentItem.userAnswer} readOnly={true} />
+          {currentItem.userAnswer.trim() === "" ? (
+            <div className="w-full resize-none rounded-lg border border-gray4 p-3 text-gray8">
+              ❌ 아무 입력을 하지 않았어요.
+            </div>
+          ) : (
+            <AnswerInput value={currentItem.userAnswer} readOnly={true} />
+          )}
         </div>
         <div className="flex flex-col">
           <span className="py-1 font-semibold text-gray8">모범 답안</span>

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -16,6 +16,19 @@ const InterviewPage = () => {
 
   const currentQuestion = questions[currentQuestionIndex];
 
+  const moveToNext = () => {
+    if (currentQuestionIndex === questions.length - 1) {
+      showToast({
+        type: "success",
+        message: "모든 답변이 성공적으로 제출되었어요. 결과 페이지로 이동할게요.",
+      });
+      navigate(`/${ROUTES.FEEDBACK}`, { state: { userId } });
+    } else {
+      setCurrentQuestionIndex((prev) => prev + 1);
+      setAnswer("");
+    }
+  };
+
   // 답변 제출 API
   const mutation = useMutation({
     mutationFn: () =>
@@ -24,18 +37,7 @@ const InterviewPage = () => {
         questionId: currentQuestion.id,
         userAnswer: answer,
       }),
-    onSuccess: () => {
-      if (currentQuestionIndex === questions.length - 1) {
-        showToast({
-          type: "success",
-          message: "모든 답변이 성공적으로 제출되었어요. 결과 페이지로 이동할게요.",
-        });
-        navigate(`/${ROUTES.FEEDBACK}`, { state: { userId } });
-      } else {
-        setCurrentQuestionIndex((prev) => prev + 1);
-        setAnswer("");
-      }
-    },
+    onSuccess: () => moveToNext(),
     onError: (error) => {
       showToast({ type: "error", message: (error as Error).message });
     },

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -16,8 +16,11 @@ const InterviewPage = () => {
 
   const currentQuestion = questions[currentQuestionIndex];
 
+  // 다음 질문으로 이동하거나 마지막 질문이면 결과 페이지로 이동
   const moveToNext = () => {
-    if (currentQuestionIndex === questions.length - 1) {
+    const isLast = currentQuestionIndex === questions.length - 1;
+
+    if (isLast) {
       showToast({
         type: "success",
         message: "모든 답변이 성공적으로 제출되었어요. 결과 페이지로 이동할게요.",
@@ -29,7 +32,7 @@ const InterviewPage = () => {
     }
   };
 
-  // 답변 제출 API
+  // 답변 제출 API 요청
   const mutation = useMutation({
     mutationFn: () =>
       postUserAnswer({
@@ -48,10 +51,12 @@ const InterviewPage = () => {
       className="mx-auto flex w-full max-w-[1200px] flex-col"
       style={{ height: "calc(100vh - 130px)" }}
     >
+      {/* 타이머 영역 */}
       <div className="flex w-full justify-center py-6">
         <Timer key={currentQuestion.id} time={currentQuestion.time} />
       </div>
 
+      {/* 질문 및 답변 입력 영역 */}
       <div className="flex w-full max-w-[1200px] flex-1 flex-col px-4">
         <Question text={currentQuestion.content} />
         <div className="flex flex-1">
@@ -64,6 +69,7 @@ const InterviewPage = () => {
         </div>
       </div>
 
+      {/* 하단 네비게이션 영역 */}
       <div className="flex w-full max-w-[1200px] items-center justify-between p-4 pt-6">
         <div className="flex-1"></div>
         <Counter current={currentQuestionIndex + 1} total={totalCount} />

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { postUserAnswer } from "../api/question";
 import { AnswerInput, Button, Counter, Question, Timer } from "../components/common";
@@ -13,6 +13,7 @@ const InterviewPage = () => {
 
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [answer, setAnswer] = useState("");
+  const [canSubmit, setCanSubmit] = useState(false);
 
   const currentQuestion = questions[currentQuestionIndex];
 
@@ -46,6 +47,15 @@ const InterviewPage = () => {
     },
   });
 
+  // 버튼 활성화 타이머 (30초)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setCanSubmit(true);
+    }, 30000);
+
+    return () => clearTimeout(timer);
+  }, [currentQuestionIndex]);
+
   return (
     <div
       className="mx-auto flex w-full max-w-[1200px] flex-col"
@@ -53,7 +63,16 @@ const InterviewPage = () => {
     >
       {/* 타이머 영역 */}
       <div className="flex w-full justify-center py-6">
-        <Timer key={currentQuestion.id} time={currentQuestion.time} />
+        <Timer
+          key={currentQuestion.id}
+          time={currentQuestion.time}
+          onBeforeEnd={() => {
+            showToast({ type: "info", message: "10초 후에 다음 질문으로 넘어갑니다!" });
+          }}
+          onTimeOver={() => {
+            mutation.mutate();
+          }}
+        />
       </div>
 
       {/* 질문 및 답변 입력 영역 */}
@@ -81,6 +100,7 @@ const InterviewPage = () => {
               mutation.mutate();
             }}
             className="bg-blue3 text-lg text-white shadow-md"
+            disabled={!canSubmit}
           />
         </div>
       </div>

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { postUserAnswer } from "../api/question";
 import { AnswerInput, Button, Counter, Question, Timer } from "../components/common";
 import { ROUTES } from "../constants";
+import showToast from "../utils/toast";
 
 const InterviewPage = () => {
   const navigate = useNavigate();
@@ -25,7 +26,10 @@ const InterviewPage = () => {
       }),
     onSuccess: () => {
       if (currentQuestionIndex === questions.length - 1) {
-        alert("모든 답변이 성공적으로 제출되었어요. 결과 페이지로 이동할게요.");
+        showToast({
+          type: "success",
+          message: "모든 답변이 성공적으로 제출되었어요. 결과 페이지로 이동할게요.",
+        });
         navigate(`/${ROUTES.FEEDBACK}`, { state: { userId } });
       } else {
         setCurrentQuestionIndex((prev) => prev + 1);
@@ -33,7 +37,7 @@ const InterviewPage = () => {
       }
     },
     onError: (error) => {
-      alert((error as Error).message);
+      showToast({ type: "error", message: (error as Error).message });
     },
   });
 

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -9,7 +9,7 @@ import showToast from "../utils/toast";
 const InterviewPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { userId, totalCount, questions } = location.state;
+  const { userId, interviewId, totalCount, questions } = location.state;
 
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [answer, setAnswer] = useState("");
@@ -27,7 +27,7 @@ const InterviewPage = () => {
         type: "success",
         message: "모든 답변이 성공적으로 제출되었어요. 결과 페이지로 이동할게요.",
       });
-      navigate(`/${ROUTES.FEEDBACK}`, { state: { userId } });
+      navigate(`/${ROUTES.FEEDBACK}`, { state: { userId, interviewId } });
     } else {
       setCurrentQuestionIndex((prev) => prev + 1);
       setAnswer("");
@@ -39,6 +39,7 @@ const InterviewPage = () => {
     mutationFn: () =>
       postUserAnswer({
         userId,
+        interviewId,
         questionId: currentQuestion.id,
         userAnswer: answer,
       }),
@@ -57,7 +58,7 @@ const InterviewPage = () => {
 
     const timer = setTimeout(() => {
       setCanSubmit(true);
-    }, 30000);
+    }, 3000); // 출시 전까지는 3초로 진행
 
     return () => clearTimeout(timer);
   }, [currentQuestionIndex]);

--- a/src/pages/InterviewSetupPage.tsx
+++ b/src/pages/InterviewSetupPage.tsx
@@ -9,10 +9,12 @@ import showToast from "../utils/toast";
 const InterviewSetupPage = () => {
   const navigate = useNavigate();
 
+  // 선택된 옵션 상태
   const [jobId, setJobId] = useState("");
   const [technicalCount, setTechnicalCount] = useState("");
   const [personalityCount, setPersonalityCount] = useState("");
 
+  // 드롭다운 옵션
   const jobOptions = [
     { label: "프론트엔드", value: "0" },
     { label: "백엔드", value: "1" },
@@ -22,6 +24,7 @@ const InterviewSetupPage = () => {
     return { label: val, value: val };
   });
 
+  // 질문 요청 API 호출
   const mutation = useMutation({
     mutationFn: () =>
       postQuestionOption(Number(jobId), Number(personalityCount), Number(technicalCount)),
@@ -33,6 +36,7 @@ const InterviewSetupPage = () => {
     },
   });
 
+  // 모든 항목이 선택됐을 때만 인터뷰 시작
   const handleStartInterview = () => {
     if (!jobId || !personalityCount || !technicalCount) {
       showToast({ type: "error", message: "모든 항목을 선택해주세요." });

--- a/src/pages/InterviewSetupPage.tsx
+++ b/src/pages/InterviewSetupPage.tsx
@@ -8,12 +8,23 @@ import showToast from "../utils/toast";
 
 const InterviewSetupPage = () => {
   const navigate = useNavigate();
+
+  const [jobId, setJobId] = useState("");
   const [technicalCount, setTechnicalCount] = useState("");
   const [personalityCount, setPersonalityCount] = useState("");
-  const countOptions = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+
+  const jobOptions = [
+    { label: "프론트엔드", value: "0" },
+    { label: "백엔드", value: "1" },
+  ];
+  const countOptions = Array.from({ length: 10 }, (_, i) => {
+    const val = (i + 1).toString();
+    return { label: val, value: val };
+  });
 
   const mutation = useMutation({
-    mutationFn: () => postQuestionOption(Number(technicalCount), Number(personalityCount)),
+    mutationFn: () =>
+      postQuestionOption(Number(jobId), Number(personalityCount), Number(technicalCount)),
     onSuccess: (data) => {
       navigate(`/${ROUTES.INTERVIEW}`, { state: data });
     },
@@ -23,8 +34,8 @@ const InterviewSetupPage = () => {
   });
 
   const handleStartInterview = () => {
-    if (!technicalCount || !personalityCount) {
-      showToast({ type: "error", message: "질문 개수를 모두 선택해주세요." });
+    if (!jobId || !personalityCount || !technicalCount) {
+      showToast({ type: "error", message: "모든 항목을 선택해주세요." });
       return;
     }
 
@@ -36,6 +47,16 @@ const InterviewSetupPage = () => {
       {/* 옵션 선택 영역 */}
       <div className="flex flex-1 items-center justify-center">
         <div className="flex flex-col gap-[32px]">
+          <div className="flex items-center justify-center gap-[24px]">
+            <div className="text-2xl font-semibold">직무 선택</div>
+            <SelectBox
+              options={jobOptions}
+              placeholder="인터뷰를 진행할 직무를 선택하세요 (프론트/백)"
+              value={jobId}
+              onChange={setJobId}
+            />
+          </div>
+
           <div className="flex items-center justify-center gap-[24px]">
             <div className="text-2xl font-semibold">인성 질문</div>
             <SelectBox

--- a/src/pages/InterviewSetupPage.tsx
+++ b/src/pages/InterviewSetupPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { postQuestionOption } from "../api/question";
 import { Button, SelectBox } from "../components/common";
 import { ROUTES } from "../constants";
+import showToast from "../utils/toast";
 
 const InterviewSetupPage = () => {
   const navigate = useNavigate();
@@ -17,13 +18,13 @@ const InterviewSetupPage = () => {
       navigate(`/${ROUTES.INTERVIEW}`, { state: data });
     },
     onError: (error) => {
-      alert((error as Error).message);
+      showToast({ type: "error", message: (error as Error).message });
     },
   });
 
   const handleStartInterview = () => {
     if (!technicalCount || !personalityCount) {
-      alert("질문 개수를 모두 선택해주세요.");
+      showToast({ type: "error", message: "질문 개수를 모두 선택해주세요." });
       return;
     }
 

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -8,6 +8,7 @@ const LandingPage = () => {
   const navigate = useNavigate();
   const { isLogin } = useAuth();
 
+  // 시작하기 버튼 클릭 시 로그인 여부에 따라 경로 분기
   const handleStartClick = () => {
     if (isLogin) {
       showToast({ type: "info", message: "이미 로그인 상태입니다. 본 인터뷰로 이동합니다." });

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,9 +1,21 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "../components/common";
 import { ROUTES } from "../constants";
+import { useAuth } from "../hooks/useAuth";
+import showToast from "../utils/toast";
 
 const LandingPage = () => {
   const navigate = useNavigate();
+  const { isLogin } = useAuth();
+
+  const handleStartClick = () => {
+    if (isLogin) {
+      showToast({ type: "info", message: "이미 로그인 상태입니다. 본 인터뷰로 이동합니다." });
+      navigate(`/${ROUTES.OPTION}`);
+    } else {
+      navigate(`/${ROUTES.PRE_OPTION}`);
+    }
+  };
 
   return (
     <div
@@ -22,12 +34,10 @@ const LandingPage = () => {
         </p>
       </section>
 
-      {/* 버튼 영역 */}
+      {/* 시작하기 버튼 */}
       <Button
-        label="시작하기"
-        onClick={() => {
-          navigate(`/${ROUTES.OPTION}`);
-        }}
+        label={isLogin ? "바로 인터뷰 시작하기" : "시작하기 (맛보기)"}
+        onClick={handleStartClick}
         className="bg-blue3 text-2xl font-semibold text-white shadow-md"
       />
 

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -9,17 +9,19 @@ const OAuthCallback = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { loginWithCode } = useAuth();
-  const hasCalled = useRef(false);
+  const hasCalled = useRef(false); // 중복 호출 방지 플래그 (Strict Mode 대응)
 
   useEffect(() => {
     const code = searchParams.get("code");
 
+    // 인증 코드가 없을 경우 홈으로 리디렉션
     if (!code) {
       showToast({ type: "error", message: "인증 코드가 없어요. 잠시 후 다시 시도해주세요." });
       navigate(ROUTES.ROOT, { replace: true });
       return;
     }
 
+    // 로그인 로직이 이미 호출된 경우 중단
     if (hasCalled.current) {
       console.warn("[OAuthCallback] 이미 로그인 호출됨");
       return;
@@ -27,6 +29,7 @@ const OAuthCallback = () => {
 
     hasCalled.current = true;
 
+    // GitHub 로그인 처리
     const login = async () => {
       try {
         await loginWithCode(code);

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -13,6 +13,17 @@ const OAuthCallback = () => {
 
   useEffect(() => {
     const code = searchParams.get("code");
+    const state = searchParams.get("state");
+    const savedState = sessionStorage.getItem("oauth_state");
+
+    sessionStorage.removeItem("oauth_state");
+
+    // state가 없을 경우 홈으로 리디렉션
+    if (!state || state !== savedState) {
+      showToast({ type: "error", message: "보안 검증에 실패했습니다. 다시 시도해주세요." });
+      navigate(ROUTES.ROOT, { replace: true });
+      return;
+    }
 
     // 인증 코드가 없을 경우 홈으로 리디렉션
     if (!code) {

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { LoadingFallback } from "../components/common";
 import { ROUTES } from "../constants";
 import { useAuth } from "../hooks/useAuth";
+import showToast from "../utils/toast";
 
 const OAuthCallback = () => {
   const [searchParams] = useSearchParams();
@@ -14,7 +15,7 @@ const OAuthCallback = () => {
     const code = searchParams.get("code");
 
     if (!code) {
-      alert("인증 코드가 없어요. 잠시 후 다시 시도해주세요.");
+      showToast({ type: "error", message: "인증 코드가 없어요. 잠시 후 다시 시도해주세요." });
       navigate(ROUTES.ROOT, { replace: true });
       return;
     }
@@ -32,7 +33,7 @@ const OAuthCallback = () => {
         navigate(ROUTES.ROOT, { replace: true });
       } catch (error) {
         console.error("[OAuthCallback] 로그인 실패:", error);
-        alert((error as Error).message);
+        showToast({ type: "error", message: (error as Error).message });
         navigate(ROUTES.ROOT, { replace: true });
       }
     };

--- a/src/pages/PreFeedbackPage.tsx
+++ b/src/pages/PreFeedbackPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { AnswerInput, Button, Counter, ModelAnswer, Question } from "../components/common";
+import { AnswerInput, Button, Counter, Modal, ModelAnswer, Question } from "../components/common";
 import { ROUTES } from "../constants";
 
 const PreFeedbackPage = () => {
@@ -8,22 +8,66 @@ const PreFeedbackPage = () => {
   const location = useLocation();
   const { results, totalCount } = location.state ?? {};
 
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   useEffect(() => {
     if (!results || !totalCount) {
       navigate(ROUTES.ROOT, { replace: true });
     }
   }, [results, totalCount, navigate]);
 
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const currentItem = results?.[currentQuestionIndex];
-
   if (!currentItem) return null;
+
+  const redirectToGithubAuthorize = () => {
+    const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID;
+    const redirectUri = import.meta.env.VITE_GITHUB_REDIRECT_URI;
+
+    if (!clientId || !redirectUri) {
+      console.error("[GitHubLogin] OAuth 설정 누락");
+      return;
+    }
+
+    const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user user:email`;
+    window.location.href = githubAuthUrl;
+  };
 
   return (
     <div
       className="mx-auto flex h-full w-full max-w-[1200px] flex-col"
       style={{ height: "calc(100vh - 130px)" }}
     >
+      {/* 모달 */}
+      <Modal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title="지금, 더 깊이 있는 인터뷰 경험을 시작해보세요"
+        content={
+          <>
+            <p className="mb-2">지금 회원가입하면,</p>
+            <ul className="list-disc pl-5">
+              <li>다양한 직무 및 난이도의 질문을 자유롭게 선택할 수 있습니다.</li>
+              <li>AI 분석 기반의 구조화된 피드백으로 역량을 성장시켜보세요.</li>
+            </ul>
+          </>
+        }
+        actions={
+          <>
+            <Button
+              className="border border-blue3 bg-blue3 text-white"
+              onClick={() => redirectToGithubAuthorize()}
+            >
+              회원가입 후 인터뷰 이어가기
+            </Button>
+            <Button className="border border-gray4 text-blue3" onClick={() => navigate("/")}>
+              홈으로 돌아가기
+            </Button>
+          </>
+        }
+      />
+
+      {/* 피드백 페이지 */}
       <div className="flex w-full max-w-[1200px] flex-1 flex-col px-4 py-6">
         <Question text={currentItem.content} />
         <div className="mb-2 flex flex-col">
@@ -35,7 +79,6 @@ const PreFeedbackPage = () => {
           <ModelAnswer text={currentItem.modelAnswer} />
         </div>
       </div>
-
       <div className="flex w-full max-w-[1200px] items-center justify-between p-4 pt-6">
         <div className="flex-1"></div>
         <Counter current={currentQuestionIndex + 1} total={totalCount} />
@@ -43,7 +86,7 @@ const PreFeedbackPage = () => {
           {currentQuestionIndex === results.length - 1 ? (
             <Button
               label="나가기"
-              onClick={() => navigate(ROUTES.ROOT)}
+              onClick={() => setIsModalOpen(true)}
               className="bg-blue3 text-lg text-white shadow-md"
             />
           ) : (

--- a/src/pages/PreFeedbackPage.tsx
+++ b/src/pages/PreFeedbackPage.tsx
@@ -73,7 +73,7 @@ const PreFeedbackPage = () => {
         <div className="mb-2 flex flex-col">
           <span className="py-1 font-semibold text-gray8">작성 답안</span>
           {currentItem.userAnswer.trim() === "" ? (
-            <div className="w-full resize-none rounded-lg border border-gray4 p-3 text-gray8">
+            <div className="w-full resize-none rounded-lg border border-gray4 p-3 italic text-gray6">
               ❌ 아무 입력을 하지 않았어요.
             </div>
           ) : (
@@ -82,8 +82,8 @@ const PreFeedbackPage = () => {
         </div>
         <div className="flex flex-col">
           <span className="py-1 font-semibold text-gray8">모범 답안</span>
-          {currentItem.modelAnswer.trim() === "" ? (
-            <div className="w-full resize-none rounded-lg border border-gray4 p-3 italic text-gray5">
+          {(currentItem.modelAnswer ?? "").trim() === "" ? (
+            <div className="w-full resize-none rounded-lg border border-gray4 bg-gray2 p-3 italic text-gray6">
               ❗ 모범 답안이 제공되지 않았어요.
             </div>
           ) : (

--- a/src/pages/PreFeedbackPage.tsx
+++ b/src/pages/PreFeedbackPage.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { AnswerInput, Button, Counter, ModelAnswer, Question } from "../components/common";
+import { ROUTES } from "../constants";
+
+const PreFeedbackPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { results, totalCount } = location.state ?? {};
+
+  useEffect(() => {
+    if (!results || !totalCount) {
+      navigate(ROUTES.ROOT, { replace: true });
+    }
+  }, [results, totalCount, navigate]);
+
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+  const currentItem = results?.[currentQuestionIndex];
+
+  if (!currentItem) return null;
+
+  return (
+    <div
+      className="mx-auto flex h-full w-full max-w-[1200px] flex-col"
+      style={{ height: "calc(100vh - 130px)" }}
+    >
+      <div className="flex w-full max-w-[1200px] flex-1 flex-col px-4 py-6">
+        <Question text={currentItem.content} />
+        <div className="mb-2 flex flex-col">
+          <span className="py-1 font-semibold text-gray8">작성 답안</span>
+          <AnswerInput value={currentItem.userAnswer} readOnly={true} />
+        </div>
+        <div className="flex flex-col">
+          <span className="py-1 font-semibold text-gray8">모범 답안</span>
+          <ModelAnswer text={currentItem.modelAnswer} />
+        </div>
+      </div>
+
+      <div className="flex w-full max-w-[1200px] items-center justify-between p-4 pt-6">
+        <div className="flex-1"></div>
+        <Counter current={currentQuestionIndex + 1} total={totalCount} />
+        <div className="flex flex-1 justify-end">
+          {currentQuestionIndex === results.length - 1 ? (
+            <Button
+              label="나가기"
+              onClick={() => navigate(ROUTES.ROOT)}
+              className="bg-blue3 text-lg text-white shadow-md"
+            />
+          ) : (
+            <Button
+              label="다음"
+              onClick={() => setCurrentQuestionIndex((prev) => prev + 1)}
+              className="bg-blue3 text-lg text-white shadow-md"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PreFeedbackPage;

--- a/src/pages/PreFeedbackPage.tsx
+++ b/src/pages/PreFeedbackPage.tsx
@@ -72,11 +72,23 @@ const PreFeedbackPage = () => {
         <Question text={currentItem.content} />
         <div className="mb-2 flex flex-col">
           <span className="py-1 font-semibold text-gray8">작성 답안</span>
-          <AnswerInput value={currentItem.userAnswer} readOnly={true} />
+          {currentItem.userAnswer.trim() === "" ? (
+            <div className="w-full resize-none rounded-lg border border-gray4 p-3 text-gray8">
+              ❌ 아무 입력을 하지 않았어요.
+            </div>
+          ) : (
+            <AnswerInput value={currentItem.userAnswer} readOnly={true} />
+          )}
         </div>
         <div className="flex flex-col">
           <span className="py-1 font-semibold text-gray8">모범 답안</span>
-          <ModelAnswer text={currentItem.modelAnswer} />
+          {currentItem.modelAnswer.trim() === "" ? (
+            <div className="w-full resize-none rounded-lg border border-gray4 p-3 italic text-gray5">
+              ❗ 모범 답안이 제공되지 않았어요.
+            </div>
+          ) : (
+            <ModelAnswer text={currentItem.modelAnswer} />
+          )}
         </div>
       </div>
 

--- a/src/pages/PreInterviewPage.tsx
+++ b/src/pages/PreInterviewPage.tsx
@@ -18,13 +18,15 @@ const PreInterviewPage = () => {
 
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [answer, setAnswer] = useState("");
-  const [userAnswers, setUserAnswers] = useState<string[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>(new Array(total).fill(""));
 
   const currentQuestion = questions[currentQuestionIndex];
 
   // 다음 질문으로 넘어가거나 마지막이면 결과 페이지로 이동
   const handleNext = () => {
     const updatedAnswers = [...userAnswers, answer];
+    updatedAnswers[currentQuestionIndex] = answer;
+
     const isLast = currentQuestionIndex === questions.length - 1;
 
     if (isLast) {
@@ -32,7 +34,7 @@ const PreInterviewPage = () => {
         id: q.id,
         content: q.content,
         modelAnswer: q.modelAnswer,
-        userAnswer: updatedAnswers[i],
+        userAnswer: updatedAnswers[i] ?? "",
       }));
 
       showToast({ type: "info", message: "모든 답변이 제출되었어요. 결과 페이지로 이동합니다." });
@@ -43,7 +45,7 @@ const PreInterviewPage = () => {
     } else {
       setUserAnswers(updatedAnswers);
       setCurrentQuestionIndex((prev) => prev + 1);
-      setAnswer("");
+      setAnswer(updatedAnswers[currentQuestionIndex + 1] ?? "");
     }
   };
 

--- a/src/pages/PreInterviewPage.tsx
+++ b/src/pages/PreInterviewPage.tsx
@@ -24,8 +24,10 @@ const PreInterviewPage = () => {
 
   // 다음 질문으로 넘어가거나 마지막이면 결과 페이지로 이동
   const handleNext = () => {
-    const updatedAnswers = [...userAnswers, answer];
+    const updatedAnswers = [...userAnswers];
     updatedAnswers[currentQuestionIndex] = answer;
+
+    setUserAnswers(updatedAnswers);
 
     const isLast = currentQuestionIndex === questions.length - 1;
 
@@ -43,7 +45,6 @@ const PreInterviewPage = () => {
         state: { results: feedbackData, totalCount: total },
       });
     } else {
-      setUserAnswers(updatedAnswers);
       setCurrentQuestionIndex((prev) => prev + 1);
       setAnswer(updatedAnswers[currentQuestionIndex + 1] ?? "");
     }

--- a/src/pages/PreInterviewPage.tsx
+++ b/src/pages/PreInterviewPage.tsx
@@ -22,10 +22,12 @@ const PreInterviewPage = () => {
 
   const currentQuestion = questions[currentQuestionIndex];
 
+  // 다음 질문으로 넘어가거나 마지막이면 결과 페이지로 이동
   const handleNext = () => {
     const updatedAnswers = [...userAnswers, answer];
+    const isLast = currentQuestionIndex === questions.length - 1;
 
-    if (currentQuestionIndex === questions.length - 1) {
+    if (isLast) {
       const feedbackData = questions.map((q: Question, i: number) => ({
         id: q.id,
         content: q.content,
@@ -50,10 +52,12 @@ const PreInterviewPage = () => {
       className="mx-auto flex w-full max-w-[1200px] flex-col"
       style={{ height: "calc(100vh - 130px)" }}
     >
+      {/* 타이머 영역 */}
       <div className="flex w-full justify-center py-6">
         <Timer key={currentQuestion.id} time={currentQuestion.time} />
       </div>
 
+      {/* 질문 및 답변 입력 영역 */}
       <div className="flex w-full max-w-[1200px] flex-1 flex-col px-4">
         <Question text={currentQuestion.content} />
         <div className="flex flex-1">
@@ -66,6 +70,7 @@ const PreInterviewPage = () => {
         </div>
       </div>
 
+      {/* 하단 네비게이션 영역 */}
       <div className="flex w-full max-w-[1200px] items-center justify-between p-4 pt-6">
         <div className="flex-1"></div>
         <Counter current={currentQuestionIndex + 1} total={total} />

--- a/src/pages/PreInterviewPage.tsx
+++ b/src/pages/PreInterviewPage.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { AnswerInput, Button, Counter, Question, Timer } from "../components/common";
+import { ROUTES } from "../constants";
+import showToast from "../utils/toast";
+
+interface Question {
+  id: number;
+  content: string;
+  modelAnswer: string;
+  time: number;
+}
+
+const PreInterviewPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { total, questions } = location.state;
+
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+  const [answer, setAnswer] = useState("");
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
+
+  const currentQuestion = questions[currentQuestionIndex];
+
+  const handleNext = () => {
+    const updatedAnswers = [...userAnswers, answer];
+
+    if (currentQuestionIndex === questions.length - 1) {
+      const feedbackData = questions.map((q: Question, i: number) => ({
+        id: q.id,
+        content: q.content,
+        modelAnswer: q.modelAnswer,
+        userAnswer: updatedAnswers[i],
+      }));
+
+      showToast({ type: "info", message: "모든 답변이 제출되었어요. 결과 페이지로 이동합니다." });
+
+      navigate(`/${ROUTES.PRE_FEEDBACK}`, {
+        state: { results: feedbackData, totalCount: total },
+      });
+    } else {
+      setUserAnswers(updatedAnswers);
+      setCurrentQuestionIndex((prev) => prev + 1);
+      setAnswer("");
+    }
+  };
+
+  return (
+    <div
+      className="mx-auto flex w-full max-w-[1200px] flex-col"
+      style={{ height: "calc(100vh - 130px)" }}
+    >
+      <div className="flex w-full justify-center py-6">
+        <Timer key={currentQuestion.id} time={currentQuestion.time} />
+      </div>
+
+      <div className="flex w-full max-w-[1200px] flex-1 flex-col px-4">
+        <Question text={currentQuestion.content} />
+        <div className="flex flex-1">
+          <AnswerInput
+            key={currentQuestion.id}
+            isFixedHeight={true}
+            value={answer}
+            onChange={(e) => setAnswer(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="flex w-full max-w-[1200px] items-center justify-between p-4 pt-6">
+        <div className="flex-1"></div>
+        <Counter current={currentQuestionIndex + 1} total={total} />
+        <div className="flex flex-1 justify-end">
+          <Button
+            label={currentQuestionIndex === questions.length - 1 ? "결과 보기" : "다음"}
+            onClick={(event) => {
+              event.preventDefault();
+              handleNext();
+            }}
+            className="bg-blue3 text-lg text-white shadow-md"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PreInterviewPage;

--- a/src/pages/PreInterviewPage.tsx
+++ b/src/pages/PreInterviewPage.tsx
@@ -4,7 +4,7 @@ import { AnswerInput, Button, Counter, Question, Timer } from "../components/com
 import { ROUTES } from "../constants";
 import showToast from "../utils/toast";
 
-interface Question {
+interface PreQuestion {
   id: number;
   content: string;
   modelAnswer: string;
@@ -32,7 +32,7 @@ const PreInterviewPage = () => {
     const isLast = currentQuestionIndex === questions.length - 1;
 
     if (isLast) {
-      const feedbackData = questions.map((q: Question, i: number) => ({
+      const feedbackData = questions.map((q: PreQuestion, i: number) => ({
         id: q.id,
         content: q.content,
         modelAnswer: q.modelAnswer,

--- a/src/pages/PreInterviewSetupPage.tsx
+++ b/src/pages/PreInterviewSetupPage.tsx
@@ -9,13 +9,16 @@ import showToast from "../utils/toast";
 const PreInterviewSetupPage = () => {
   const navigate = useNavigate();
 
+  // 직무 선택 상태
   const [jobId, setJobId] = useState("");
 
+  // 직무 옵션 리스트
   const jobOptions = [
     { label: "프론트엔드", value: "0" },
     { label: "백엔드", value: "1" },
   ];
 
+  // 직무 기반 질문 요청 API
   const mutation = useMutation({
     mutationFn: () => postJobIdOption(Number(jobId)),
     onSuccess: (data) => {
@@ -26,6 +29,7 @@ const PreInterviewSetupPage = () => {
     },
   });
 
+  // 시작 버튼 클릭 시 처리
   const handleStartInterview = () => {
     if (!jobId) {
       showToast({ type: "error", message: "직무를 선택해주세요." });

--- a/src/pages/PreInterviewSetupPage.tsx
+++ b/src/pages/PreInterviewSetupPage.tsx
@@ -1,0 +1,67 @@
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { postJobIdOption } from "../api/question";
+import { Button, SelectBox } from "../components/common";
+import { ROUTES } from "../constants";
+import showToast from "../utils/toast";
+
+const PreInterviewSetupPage = () => {
+  const navigate = useNavigate();
+
+  const [jobId, setJobId] = useState("");
+
+  const jobOptions = [
+    { label: "프론트엔드", value: "0" },
+    { label: "백엔드", value: "1" },
+  ];
+
+  const mutation = useMutation({
+    mutationFn: () => postJobIdOption(Number(jobId)),
+    onSuccess: (data) => {
+      navigate(`/${ROUTES.PRE_INTERVIEW}`, { state: data });
+    },
+    onError: (error) => {
+      showToast({ type: "error", message: (error as Error).message });
+    },
+  });
+
+  const handleStartInterview = () => {
+    if (!jobId) {
+      showToast({ type: "error", message: "직무를 선택해주세요." });
+      return;
+    }
+
+    mutation.mutate();
+  };
+
+  return (
+    <div className="flex w-full max-w-[1200px] flex-col" style={{ height: "calc(100vh - 130px)" }}>
+      {/* 옵션 선택 영역 */}
+      <div className="flex flex-1 items-center justify-center">
+        <div className="flex flex-col gap-[32px]">
+          <div className="flex items-center justify-center gap-[24px]">
+            <div className="text-2xl font-semibold">직무 선택</div>
+            <SelectBox
+              options={jobOptions}
+              placeholder="인터뷰를 진행할 직무를 선택하세요 (프론트/백)"
+              value={jobId}
+              onChange={setJobId}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* 버튼 영역 */}
+      <div className="flex justify-end px-4 py-6">
+        <Button
+          label="인터뷰 시작하기"
+          onClick={handleStartInterview}
+          className="bg-blue3 text-lg text-white shadow-md"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PreInterviewSetupPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -3,3 +3,6 @@ export { default as InterviewPage } from "./InterviewPage";
 export { default as InterviewSetupPage } from "./InterviewSetupPage";
 export { default as LandingPage } from "./LandingPage";
 export { default as OAuthCallbackPage } from "./OAuthCallback";
+export { default as PreFeedbackPage } from "./PreFeedbackPage";
+export { default as PreInterviewPage } from "./PreInterviewPage";
+export { default as PreInterviewSetupPage } from "./PreInterviewSetupPage";

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -7,7 +7,13 @@ const redirectToGithubAuthorize = () => {
     return;
   }
 
-  const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user user:email`;
+  // CSRF 방지를 위한 state
+  const state = crypto.randomUUID
+    ? crypto.randomUUID()
+    : Math.random().toString(36).substring(2, 15);
+  sessionStorage.setItem("oauth_state", state);
+
+  const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user user:email&state=${state}`;
   window.location.href = githubAuthUrl;
 };
 

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -1,0 +1,14 @@
+const redirectToGithubAuthorize = () => {
+  const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID;
+  const redirectUri = import.meta.env.VITE_GITHUB_REDIRECT_URI;
+
+  if (!clientId || !redirectUri) {
+    console.error("[GitHubLogin] OAuth 설정 누락");
+    return;
+  }
+
+  const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user user:email`;
+  window.location.href = githubAuthUrl;
+};
+
+export default redirectToGithubAuthorize;

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -1,0 +1,15 @@
+import { toast } from "sonner";
+import { CustomToast } from "../components/common";
+
+type ToastType = "success" | "error" | "info" | "warning";
+
+interface ShowToastProps {
+  type: ToastType;
+  message: string;
+}
+
+const showToast = ({ type, message }: ShowToastProps) => {
+  toast.custom((id) => <CustomToast type={type} message={message} />);
+};
+
+export default showToast;

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -9,7 +9,7 @@ interface ShowToastProps {
 }
 
 const showToast = ({ type, message }: ShowToastProps) => {
-  toast.custom((id) => <CustomToast type={type} message={message} />);
+  toast.custom(() => <CustomToast type={type} message={message} />);
 };
 
 export default showToast;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,7 @@ export default {
         gray7: "var(--color-gray7)",
         gray8: "var(--color-gray8)",
         black: "var(--color-black)",
+        "black-60": "rgba(0, 0, 0, 0.6)",
         background: "var(--color-background)",
         blue1: "var(--color-blue1)",
         blue2: "var(--color-blue2)",


### PR DESCRIPTION
## 🔗 관련 이슈

- closed: #17 
- closed: #18

<br>

## 📌 PR 세부 내용

### 📝 개요
이 PR에서는 로그인 여부에 따른 인터뷰 흐름 분기, UX 개선, 커스텀 토스트 및 모달 시스템 도입을 중심으로 기능을 확장하고 구조를 개선했습니다.
전체 변경사항은 크게 5가지로 구분됩니다.

<br>

### 🚀 기능 구현 / 주요 변경 사항
- **옵션 선택 페이지에서 직무 선택 SelectBox 추가**
  - 프론트엔드 / 백엔드 직무 선택 가능하도록 구현
  - 맛보기용 직무 기반 질문 요청 API 연결 (`/prequestion`)
  
- **로그인 여부에 따른 인터뷰 흐름 분기 및 페이지 분리**
  - `LandingPage`에서 로그인 상태에 따라 버튼 라벨 및 인터뷰 경로 분기
  - 비로그인 사용자는 `PreInterviewSetup -> PreInterview → PreFeedback` 흐름을 따르도록 구현
    - `PreInterviewSetupPage` : 직무(프론트/백) 선택
    - `PreInterviewPage` : 기술질문1개, 인성질문 1개 인터뷰 진행
    - `PreFeedbackPage` : 기술질문, 인성질문 답안 제공 및 회원가입 유도 모달 띄우기

- **본 인터뷰 흐름 내 UX 개선 (타이머 기반 인터랙션)**
  - 타이머 30초 경과 후 버튼 활성화
  - 시간 종료 시 자동 제출 및 다음 질문으로 이동
  - 마지막 질문 이후 결과 페이지 자동 이동

- **커스텀 Toast 시스템 구현 및 전역 적용**
  - `sonner` 기반 CustomToast 컴포넌트 및 `showToast` 유틸 함수 도입
  - 기존 alert 전면 교체 (로그인/로그아웃, 오류, 안내 메시지에 적용)

- **공통 Modal 시스템 도입 및 회원가입 유도 모달 구현**
  - Modal 컴포넌트 공통 구현 (portal 방식)

<br>

### 🧱 구조 개선 / 리팩터링
- `alert` → 커스텀 toast(`showToast`)로 전면 교체
- 로그인 / 로그아웃, 인증 실패 등 전체 흐름에 토스트 적용
- SelectBox option 구조 개선 (`{ label, value }` 형태로 통일)

<br>

### 🛠 개발 환경 개선 / 테스트 대응
- `sonner` 라이브러리 도입
- `index.html`에 `#modal-root` 추가

<br>

### 📎 기타 참고 사항
- 비로그인 사용자

| 홈 화면 | 옵션 선택 화면 |
|---|---|
|![image](https://github.com/user-attachments/assets/ba22153d-33a0-4cbf-a1d1-03f160e47b96)| ![image](https://github.com/user-attachments/assets/a5b45127-2d92-4016-9390-1039d534da88)|

|질문1 (타이머 부수 기능 X) |답변1 |
|---|---|
| ![image](https://github.com/user-attachments/assets/e9404263-f551-4da6-a85a-7609d604271f)|![image](https://github.com/user-attachments/assets/59ba61ef-3e76-4865-bf04-14477850055c) |

| 질문2 이후 회원가입 유도 모달| "회원가입 후 인터뷰 이어가기" 버튼 클릭시|
|---|---|
|![image](https://github.com/user-attachments/assets/063a9343-3504-4f5b-82dc-80580d13b12f) |![image](https://github.com/user-attachments/assets/c261a742-10dc-4015-b400-ae74706260d0) |

- 로그인 사용자

| 홈 화면 | 옵션 선택 화면 |
|---|---|
| ![image](https://github.com/user-attachments/assets/e3554777-2f4a-470e-b031-215965b67660)|![image](https://github.com/user-attachments/assets/75be2c14-bbce-4ebd-9df0-c3a1ac08c0b1) |

| 질문1  | 질문1 버튼 활성화 (이후 과정은 이전과 동일) | 
|---|---|
|![image](https://github.com/user-attachments/assets/93b4dfcf-ca96-476c-89fd-9286227f238d) |![image](https://github.com/user-attachments/assets/41b25eaa-e95d-4fc4-95dd-71e9b306bd84) |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced "pre-interview" functionality with setup, question answering, and feedback pages for non-logged-in users.
  - Added modal and custom toast components for enhanced user interaction and notifications.
  - Implemented GitHub OAuth redirection utility and unified authentication button component.
  - Enabled toast-based notifications app-wide, replacing alert dialogs.
  - Added toast notifications with type-specific icons and colors.
  - Added new routes and API endpoints supporting pre-interview flows.

- **Enhancements**
  - Enhanced SelectBox and Button components with richer options and disabled state support.
  - Improved interview and feedback flows with validation, timed submission gating, conditional navigation, and user messaging.
  - Added toast-based user feedback in multiple pages replacing alerts.
  - Refined header by consolidating authentication UI into a single component.
  - Added a new semi-transparent black color to the Tailwind CSS palette.

- **Bug Fixes**
  - Prevented duplicate submissions and improved timer-based controls in interview flows.

- **Chores**
  - Added new dependencies and improved internal documentation for clarity.
  - Updated package dependencies and added comments for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->